### PR TITLE
Add python 3.11 to build matrix

### DIFF
--- a/.github/workflows/anacopy.yml
+++ b/.github/workflows/anacopy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.7, 3.8, 3.9, "3.10"]
+        py: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu] #, macos]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/anacopy.yml
+++ b/.github/workflows/anacopy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        py: [3.7, 3.8, 3.9, "3.10", 3.11]
         os: [ubuntu] #, macos]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py:  [3.7, 3.8, 3.9, "3.10", "3.11"]
+        py:  [3.7, 3.8, 3.9, "3.10", 3.11]
         os:  [ubuntu, windows, macos]
         nm: [opencv-python-headless, sentencepiece]
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/condabuild.yml
+++ b/.github/workflows/condabuild.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py:  [3.7, 3.8, 3.9, "3.10"]
+        py:  [3.7, 3.8, 3.9, "3.10", "3.11"]
         os:  [ubuntu, windows, macos]
         nm: [opencv-python-headless, sentencepiece]
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
The packages for python 3.11 are missing, e. g. [opencv-python-headless](https://anaconda.org/fastai/opencv-python-headless/files). This PR adds python 3.11 to the build matrix.